### PR TITLE
Fix memory leak when SSR

### DIFF
--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -124,7 +124,7 @@ export default {
     }
   },
 
-  created() {
+  beforeMount() {
     ToastServiceBus.subscribers.push(this)
 
     ToastServiceBus.$on(ADD_TOAST, (toast) => {


### PR DESCRIPTION
I noticed that I have multi-gigabytes memory leaks in my SSR-enabled app. Inspection showed that it only occurs when `runInNewContext: false` set in the bundle renderer. Here's a screenshot of a memory profile:

![image](https://user-images.githubusercontent.com/8523135/46719759-6c99e680-cc77-11e8-8d26-115968f216d0.png)

As you can see, `ToastServiceBus.subscribers` keeps a reference to `ToastContainer` forever. To fix this, I made the component only subscribe client-side. As far as I have searched, this should have no side-effects to the API or the functionality.